### PR TITLE
Compress responses with Gzip, use ETags, and conditional GET

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,6 +3,9 @@ require 'rack/rewrite'
 
 use Rack::ShowExceptions
 use Rack::ShowStatus
+use Rack::Deflater
+use Rack::ETag
+use Rack::ConditionalGet
 
 # https://github.com/jtrupiano/rack-rewrite
 use Rack::Rewrite do


### PR DESCRIPTION
Prior to this commit Sinatra did not use any compression for html,css,js
responses and this left a considerable amount of room for performance
improvements. These changes also make it easier for the browser to know which
files have changed using the ETAG header and requests for content which has not
changed will receive a 304 Not Modified response and use the browser memory
cache.

I tested this in development after making changes and didn't see any delay in
the server noticing when files chanbged for live refreshes using "rake rerun".