### PR TITLE
Rack::Cache with memory store for now as reverse proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,13 +13,14 @@ gem "chronic", "~> 0.10.2"
 gem "redcarpet", "~> 2.3"
 gem "rack-ssl", "~> 1.4"
 gem "barnes", "~> 0.0.7"
+gem "nokogiri", "~> 1.7" # fixed versions, for Windows
+gem "rack-cache", "~> 1.9.0"
+gem "rake", "~> 12.3"
 gem "deckrb", git: "https://github.com/alexch/deck.rb.git"
 
 group :development, :test do
-
   gem "listen", "~> 3.1"
   gem 'wdm', '~> 0.1.0' if Gem.win_platform?
-  gem "rake", "~> 12.3"
   gem "files", "~> 0.4.0"
   gem "pry", "~> 0.12.2"
   gem "wrong", git: "https://github.com/alexch/wrong.git"
@@ -29,7 +30,3 @@ end
 group :test do
   gem "rspec", "~> 3.8"
 end
-
-
-# odd fixed versions, for Windows
-gem "nokogiri", "~>1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
       method_source (~> 0.9.0)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cache (1.9.0)
+      rack (>= 0.4)
     rack-protection (2.0.5)
       rack
     rack-rewrite (1.5.1)
@@ -159,6 +161,7 @@ DEPENDENCIES
   nokogiri (~> 1.7)
   pry (~> 0.12.2)
   puma (~> 3.12)
+  rack-cache (~> 1.9.0)
   rack-rewrite (~> 1.5)
   rack-ssl (~> 1.4)
   rake (~> 12.3)

--- a/app.rb
+++ b/app.rb
@@ -37,7 +37,10 @@ class App < Sinatra::Base
   include Erector::Mixin
   include AppHelpers
 
+  set :static_cache_control, [:public, :max_age => 300]
+
   before do
+    cache_control :public, max_age: 300
     Thread.current[:development_mode] = (request.host =~ /^(localhost|127\.0\.0\.1)$/)
   end
 

--- a/config.ru
+++ b/config.ru
@@ -1,15 +1,17 @@
 require './app'
 require 'rack/rewrite'
+require 'rack/cache'
 
 if ENV['RACK_ENV'] == 'production'
   require 'rack/ssl'
   use Rack::SSL
 end
+use Rack::Cache
+use Rack::ConditionalGet
+use Rack::ETag
+use Rack::Deflater
 use Rack::ShowExceptions
 use Rack::ShowStatus
-use Rack::Deflater
-use Rack::ETag
-use Rack::ConditionalGet
 
 # https://github.com/jtrupiano/rack-rewrite
 use Rack::Rewrite do


### PR DESCRIPTION
This is a super simple cache for storing static files and path responses instead
of sending them or generating them each time. Currently the app server is very
slow as it loads up all the Site, Track, and Lessons for every request.