### PR TITLE
Open the navigation on JS-part-time course to be open on load

### DIFF
--- a/lib/javascript_after_hours.rb
+++ b/lib/javascript_after_hours.rb
@@ -31,6 +31,16 @@ class JavascriptAfterHours < Site
   end
 
   class View < Erector::Widget
+
+    external :script, (<<-JS)
+      window.addEventListener('DOMContentLoaded', (e) => {
+        $(document).ready(function() {
+          console.log('Hi from the collapse toggle!');
+          $('#sidebar-javascript_intro-lessons').collapse('show');
+        })
+      })
+    JS
+
     def content
       div.row {
         div(class: 'col-sm') {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,8 @@
 window.addEventListener('DOMContentLoaded', (e) => {
-  hljs.configure({languages: []});
-  hljs.initHighlightingOnLoad();
+  if (window.hljs) {
+    hljs.configure({
+      languages: []
+    });
+    hljs.initHighlightingOnLoad();
+  }
 });


### PR DESCRIPTION
Because this is only a single track course, it makes sense to have the nav items
be open on load, so they are more visible when first visiting the site.