### PR TITLE
Add handlers paths for not_found and error

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -207,6 +207,15 @@ class App < Sinatra::Base
     page(thing: topic).to_html
   end
 
+  not_found do
+    status 404
+    'The requested resource cannot be found.'
+  end
+
+  error do
+    'An error has occurred'
+  end
+
   def track_dir
     track.dir
   end


### PR DESCRIPTION
Whenever a 404 or 5xx error occurred due to a bad request it would raise the error instead of handling the missing resource, this change should correct that behavior.