### PR TITLE
Enable other sites to iframe the slides

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,11 @@ class App < Sinatra::Base
     use Rollbar::Middleware::Sinatra
   end
 
-  set :static_cache_control, [:public, :max_age => 300]
+  configure do
+    set :protection, :except => :frame_options
+    set :static_cache_control, [:public, :max_age => 300]
+  end
+
 
   before do
     cache_control :public, max_age: 300


### PR DESCRIPTION
The `X-Frame-Options` header was set to `SAMEORIGIN` by Sinatra `Rack::Protection` which is a good default, but was preventing the slides from being iFramed into any other sites.